### PR TITLE
Adding SUInitialize, SUTerminate and os.path.sep for cross platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,7 @@ INSTALL
   SketchUpAPI.framework
   sketchup.cpython-37m-darwin
 
+2) Rename sketchup.cpython-37m-darwin.so to sketchup.so
+
 2) Look the addon in Blender and enable it
 

--- a/sketchup.pyx
+++ b/sketchup.pyx
@@ -943,6 +943,7 @@ cdef class Model:
 
     def __cinit__(self, **kwargs):
         self.model.ptr = <void*> 0
+        SUInitialize()
         if not '__skip_init' in kwargs:
             check_result(SUModelCreate(&(self.model)))
 
@@ -959,6 +960,10 @@ cdef class Model:
         cdef const char* f = py_byte_string
         check_result(SUModelSaveToFile(self.model, f))
         return True
+
+    def close(self):
+        SUModelRelease(&self.model)
+        SUTerminate()
 
     def NumMaterials(self):
         cdef size_t count = 0

--- a/sketchup_importer/__init__.py
+++ b/sketchup_importer/__init__.py
@@ -290,6 +290,9 @@ class SceneImporter():
 
         # hide_one_level()
 
+        # release model and terminate api
+        self.skp_model.close()
+
         return {'FINISHED'}
 
     def write_duplicateable_groups(self):
@@ -425,10 +428,10 @@ class SceneImporter():
                 default_shader_alpha.default_value = round((a / 255.0), 2)
 
                 if tex:
-                    tex_name = tex.name.split("\\")[-1]
+                    tex_name = tex.name.split(os.path.sep)[-1]
                     temp_dir = tempfile.gettempdir()
-                    skp_fname = self.filepath.split("\\")[-1].split(".")[0]
-                    temp_dir += '\\' + skp_fname
+                    skp_fname = self.filepath.split(os.path.sep)[-1].split(".")[0]
+                    temp_dir += os.path.sep + skp_fname
                     if not os.path.isdir(temp_dir):
                         os.mkdir(temp_dir)
                     temp_file_path = os.path.join(temp_dir, tex_name)


### PR DESCRIPTION
 According to support given in https://github.com/SketchUp/api-issue-tracker/issues/632, SUInitialize and SUTerminate needs to be called for the API to function correctly.

The os.path.sep replaces double backwards slashes for for cross platform support.